### PR TITLE
Uses GH_RELEASES_TOKEN secret so release triggers other workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,4 @@ jobs:
           tag_name:  ${{ steps.release.outputs.version }}
           generate_release_notes: true
           target_commitish: ${{ env.GITHUB_REF }}
+          token: ${{ secrets.GH_RELEASES_TOKEN }}


### PR DESCRIPTION
From the docs:

>When you use the repository's GITHUB_TOKEN to perform tasks on behalf of the GitHub Actions app, events triggered by the GITHUB_TOKEN will not create a new workflow run.
>https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token